### PR TITLE
Добавлено импортирование типа Attachment в utils.py

### DIFF
--- a/aiomax/utils.py
+++ b/aiomax/utils.py
@@ -1,4 +1,6 @@
 from typing import *
+
+from aiomax.types import Attachment
 from . import buttons
 from inspect import signature
 import aiohttp


### PR DESCRIPTION
Компилятор ошибку выдаёт, потому что мы записали типизацию Attachment, но нигде не импортировали её / объявили ранее ♥