### PR TITLE
Fix: correct encoding for filenames with non-ASCII characters

### DIFF
--- a/aiomax/bot.py
+++ b/aiomax/bot.py
@@ -538,7 +538,7 @@ class Bot(Router):
             async with aiofiles.open(data, "rb") as f:
                 data = await f.read()
 
-        form = aiohttp.FormData()
+        form = aiohttp.FormData(quote_fields=False)
         form.add_field(field_name, data)
 
         url_resp = await self.post(


### PR DESCRIPTION
Fixed file upload encoding issue where filenames with Russian/Unicode characters were being incorrectly encoded (e.g., _D0_B2_D1_84_D1_8B instead of proper filename).

**Changes:**

- Use aiohttp.FormData(quote_fields=False) instead of aiohttp.FormData()
- Ensures proper handling of Unicode filenames during file uploads