### PR TITLE
Pass keyboard param on send_message retry

### DIFF
--- a/aiomax/bot.py
+++ b/aiomax/bot.py
@@ -679,6 +679,7 @@ class Bot(Router):
                 reply_to=reply_to,
                 notify=notify,
                 disable_link_preview=disable_link_preview,
+                keyboard=keyboard,
                 attachments=attachments,
             )
 


### PR DESCRIPTION
В блоке except AttachmentNotReady рекурсивный вызов не передаёт keyboard