### PR TITLE
Correct get_pin parsing and preserve notify=False in pin and patch_chat

### DIFF
--- a/aiomax/bot.py
+++ b/aiomax/bot.py
@@ -307,7 +307,7 @@ class Bot(Router):
         if json["message"] is None:
             return None
 
-        return Message.from_json(json)
+        return Message.from_json(json["message"])
 
     async def pin(
         self, chat_id: int, message_id: str, notify: "bool | None" = None
@@ -320,7 +320,7 @@ class Bot(Router):
         :param notify: Whether to notify users about the pin. True by default.
         """
         payload = {"message_id": message_id, "notify": notify}
-        payload = {k: v for k, v in payload.items() if v}
+        payload = {k: v for k, v in payload.items() if v is not None}
 
         response = await self.put(
             f"https://platform-api.max.ru/chats/{chat_id}/pin", json=payload
@@ -494,7 +494,7 @@ class Bot(Router):
             "pin": pin,
             "notify": notify,
         }
-        payload = {k: v for k, v in payload.items() if v}
+        payload = {k: v for k, v in payload.items() if v is not None}
 
         response = await self.patch(
             f"https://platform-api.max.ru/chats/{chat_id}", json=payload


### PR DESCRIPTION
Два фикса:
* Метод `get_pin` передавал весь JSON-ответ в `Message.from_json` вместо `json["message"]`, что приводило к некорректному разбору закреплённого сообщения
* Фильтрация `{k: v if v}` отбрасывала `notify=False`, из-за чего отключить уведомление было невозможно
