### PR TITLE
Handle missing message field in forwarded LinkedMessage

### DIFF
--- a/aiomax/types.py
+++ b/aiomax/types.py
@@ -555,7 +555,7 @@ class LinkedMessage:
         chat_id: "int | None" = None,
     ):
         self.type: str = type
-        self.message: MessageBody = message
+        self.message: "MessageBody | None" = message
         self.sender: User = sender
         self.chat_id: "int | None" = chat_id
 
@@ -566,7 +566,7 @@ class LinkedMessage:
 
         return LinkedMessage(
             type=data["type"],
-            message=MessageBody.from_json(data["message"]),
+            message=MessageBody.from_json(data.get("message")),
             sender=User.from_json(data.get("sender")),
             chat_id=data.get("chat_id"),
         )


### PR DESCRIPTION
Часто ловлю ошибку

<img width="542" height="537" alt="image" src="https://github.com/user-attachments/assets/7c518290-b7d6-4009-90d6-f3efd284c6b8" />
