### PR TITLE
Raise on failed upload instead of crashing with KeyError: 'token'

### DIFF
--- a/aiomax/bot.py
+++ b/aiomax/bot.py
@@ -541,6 +541,7 @@ class Bot(Router):
         )
         url_json = await url_resp.json()
         token_resp = await self.session.post(url_json["url"], data=form)
+        token_resp.raise_for_status()
 
         if type in {"audio", "video"}:
             return url_json


### PR DESCRIPTION
## Проблема

В `Bot._upload` после POST на upload-сервер не проверяется HTTP-статус ответа:

```python
token_resp = await self.session.post(url_json["url"], data=form)

if type in {"audio", "video"}:
    return url_json

token_json = await token_resp.json()
return token_json
```

Если upload-сервер MAX вернул ошибку (5xx, 4xx, временные сетевые сбои), `token_json` не содержит `"token"`, и вызов падает уже в caller'е — например, в `upload_file`:

```python
raw_file = await self._upload(data, "file", filename)
token = raw_file["token"]  # KeyError: 'token'
```

Это видно в стек-трейсах прода — `KeyError: 'token'` в `aiomax/bot.py:602` без какого-либо контекста о реальной HTTP-ошибке.

## Фикс

Добавлен `token_resp.raise_for_status()` сразу после POST. Теперь при сбое загрузки выбрасывается стандартный `aiohttp.ClientResponseError` со статусом и причиной — пользовательский код может это поймать и обработать как и любую другую сетевую ошибку.

## Затрагивает

- `upload_file`
- `upload_image`
- `upload_video` / `upload_audio` (тут тоже полезно — если сама загрузка упала, не имеет смысла возвращать `url_json` и ждать обработки)